### PR TITLE
Print X window IDs in uppercase

### DIFF
--- a/xqp.c
+++ b/xqp.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
 				}
 			}
 		} else {
-			printf("0x%08x\n", qpr->child);
+			printf("0x%08X\n", qpr->child);
 		}
 	} else {
 		ret = EXIT_FAILURE;


### PR DESCRIPTION
In order to have consistency with the other `baskerville` programs which print IDs in uppercase, i.e. `bspwm`, `xlsw` and `xdo`.